### PR TITLE
fix: export guessLocationOfTsconfig from common module

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,6 +1,7 @@
 export * from './assertion';
 export * from './error';
 export * from './extraction';
+export { guessLocationOfTsconfig } from './extraction/extract-graph';
 export * from './fluentapi';
 export * from './logging';
 export * from './projection';


### PR DESCRIPTION
  ## Summary

  Export `guessLocationOfTsconfig` from the common module for Vitest 4 compatibility.

  This fixes runtime errors where Vitest 4 cannot resolve the export when users try to access
  guessLocationOfTsconfig from the ArchUnitTS common module.

  ## Changes

  - Added explicit export in src/common/index.ts
  - Enables users to customize TypeScript configuration detection

  ## Impact

  - Minimal change: 1 line added
  - Fixes Vitest 4 compatibility issue
  - No breaking changes